### PR TITLE
Always use consent prompt / "account selection" for Google SSO

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+    "**/Thumbs.db": true
+  },
+  "hide-files.files": []
+}

--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ app.get('/auth', (req, res) => {
     // Redirect to Google auth
     const authorizeUrl = userOAuth2Client.generateAuthUrl({
       access_type: 'online',
-      scope: ['profile', 'email']
+      scope: ['profile', 'email'],
+      prompt: 'consent'
     });
     res.redirect(authorizeUrl)
   }else{


### PR DESCRIPTION
Using the consent prompt would ensure that users are always able to select the correct account when logging in for cases where they have multiple choices. It would also help in cases where they sign in with their Hackney account before being granted access.

This removes the need for them to clear their cookies before trying to log in again.